### PR TITLE
Add GitHub Actions config

### DIFF
--- a/.github/workflows/tools-unstable-linux.yml
+++ b/.github/workflows/tools-unstable-linux.yml
@@ -1,0 +1,30 @@
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+name: fox32 tools Unstable - Linux
+
+jobs:
+  tools-unstable-linux:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Build
+        working-directory: gfx2inc
+        run: cargo build --release
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: gfx2inc
+          path: gfx2inc/target/release/gfx2inc


### PR DESCRIPTION
In order to build fox32os in CI, it's useful to have gfx2inc prebuilt.